### PR TITLE
expose private #studID field from ChartStudy

### DIFF
--- a/src/chart/study.js
+++ b/src/chart/study.js
@@ -147,6 +147,11 @@ const parseTrades = (trades) => trades.reverse().map((t) => ({
  */
 module.exports = (chartSession) => class ChartStudy {
   #studID = genSessionID('st');
+  
+  /** @return {string} Study ID */
+  get studyId() {
+    return this.#studID
+  }
 
   #studyListeners = chartSession.studyListeners;
 


### PR DESCRIPTION
used when you want to use the source of one study in another (like EMA of VWAP)