### PR TITLE
Optionally use 'sessionid_sign' cookie

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,7 @@ module.exports = {
         devDependencies: ['./test.js', './tests/**'],
       },
     ],
+    'no-restricted-syntax': 'off',
+    'no-await-in-loop': 'off',
   },
 };

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
   pull_request_target:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   schedule:
   - cron: '0 0 * * *'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,3 +28,4 @@ jobs:
       run: npm test
       env:
         SESSION: ${{ secrets.TW_SESSION }}
+        SIGNATURE: ${{ secrets.TW_SIGNATURE }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   push:
   pull_request_target:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
   schedule:
   - cron: '0 0 * * *'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
   schedule:
   - cron: '0 0 * * *'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
   schedule:
   - cron: '0 0 * * *'

--- a/src/client.js
+++ b/src/client.js
@@ -214,6 +214,7 @@ module.exports = class Client {
   /**
    * @typedef {Object} ClientOptions
    * @prop {string} [token] User auth token (in 'sessionid' cookie)
+   * @prop {string} [signature] User auth token signature (in 'sessionid_sign' cookie)
    * @prop {boolean} [DEBUG] Enable debug mode
    * @prop {'data' | 'prodata' | 'widgetdata'} [server] Server type
    */
@@ -230,7 +231,7 @@ module.exports = class Client {
     });
 
     if (clientOptions.token) {
-      misc.getUser(clientOptions.token).then((user) => {
+      misc.getUser(clientOptions.token, clientOptions.signature ? clientOptions.signature : '').then((user) => {
         this.#sendQueue.unshift(protocol.formatWSPacket({
           m: 'set_auth_token',
           p: [user.authToken],

--- a/src/client.js
+++ b/src/client.js
@@ -231,7 +231,10 @@ module.exports = class Client {
     });
 
     if (clientOptions.token) {
-      misc.getUser(clientOptions.token, clientOptions.signature ? clientOptions.signature : '').then((user) => {
+      misc.getUser(
+        clientOptions.token,
+        clientOptions.signature ? clientOptions.signature : '',
+      ).then((user) => {
         this.#sendQueue.unshift(protocol.formatWSPacket({
           m: 'set_auth_token',
           p: [user.authToken],

--- a/src/miscRequests.js
+++ b/src/miscRequests.js
@@ -375,8 +375,11 @@ module.exports = {
 
     if (data.error) throw new Error(data.error);
 
-    const cookie = cookies.find((c) => c.includes('sessionid='));
-    const session = (cookie.match(/sessionid=(.*?);/) ?? [])[1];
+    const sessionCookie = cookies.find((c) => c.includes('sessionid='));
+    const session = (sessionCookie.match(/sessionid=(.*?);/) ?? [])[1];
+    
+    const signCookie = cookies.find((c) => c.includes('sessionid_sign='));
+    const signature = (signCookie.match(/sessionid_sign=(.*?);/) ?? [])[1];
 
     return {
       id: data.user.id,
@@ -388,6 +391,7 @@ module.exports = {
       followers: data.user.followers,
       notifications: data.user.notification_count,
       session,
+      signature,
       sessionHash: data.user.session_hash,
       privateChannel: data.user.private_channel,
       authToken: data.user.auth_token,
@@ -399,19 +403,20 @@ module.exports = {
    * Get user from 'sessionid' cookie
    * @function getUser
    * @param {string} session User 'sessionid' cookie
+   * @param {string} [signature] User 'sessionid_sign' cookie
    * @param {string} [location] Auth page location (For france: https://fr.tradingview.com/)
    * @returns {Promise<User>} Token
    */
-  async getUser(session, location = 'https://www.tradingview.com/') {
+  async getUser(session, signature = '', location = 'https://www.tradingview.com/') {
     return new Promise((cb, err) => {
       https.get(location, {
-        headers: { cookie: `sessionid=${session}` },
+        headers: { cookie: `sessionid=${session}${signature ? `;sessionid_sign=${signature};` : ''}` },
       }, (res) => {
         let rs = '';
         res.on('data', (d) => { rs += d; });
         res.on('end', async () => {
           if (res.headers.location && location !== res.headers.location) {
-            cb(await module.exports.getUser(session, res.headers.location));
+            cb(await module.exports.getUser(session, signature, res.headers.location));
             return;
           }
           if (rs.includes('auth_token')) {
@@ -428,6 +433,7 @@ module.exports = {
                 user: parseFloat(/"notification_count":\{"following":[0-9]*,"user":([0-9]*)/.exec(rs)[1] || 0),
               },
               session,
+              signature,
               sessionHash: /"session_hash":"(.*?)"/.exec(rs)[1],
               privateChannel: /"private_channel":"(.*?)"/.exec(rs)[1],
               authToken: /"auth_token":"(.*?)"/.exec(rs)[1],
@@ -445,12 +451,13 @@ module.exports = {
    * Get user's private indicators from a 'sessionid' cookie
    * @function getPrivateIndicators
    * @param {string} session User 'sessionid' cookie
+   * @param {string} [signature] User 'sessionid_sign' cookie
    * @returns {Promise<SearchIndicatorResult[]>} Search results
    */
-  async getPrivateIndicators(session) {
+  async getPrivateIndicators(session, signature = '') {
     return new Promise((cb, err) => {
       https.get('https://pine-facade.tradingview.com/pine-facade/list?filter=saved', {
-        headers: { cookie: `sessionid=${session}` },
+        headers: { cookie: `sessionid=${session}${signature ? `;sessionid_sign=${signature};` : ''}` },
       }, (res) => {
         let rs = '';
         res.on('data', (d) => { rs += d; });
@@ -499,18 +506,19 @@ module.exports = {
    * Get a chart token from a layout ID and the user credentials if the layout is not public
    * @function getChartToken
    * @param {string} layout The layout ID found in the layout URL (Like: 'XXXXXXXX')
-   * @param {UserCredentials} [credentials] User credentials (id + session)
+   * @param {UserCredentials} [credentials] User credentials (id + session + [signature])
    * @returns {Promise<string>} Token
    */
   async getChartToken(layout, credentials = {}) {
     const creds = credentials.id && credentials.session;
     const userID = creds ? credentials.id : -1;
     const session = creds ? credentials.session : null;
+    const signature = creds ? credentials.signature : null;
 
     const { data } = await request({
       host: 'www.tradingview.com',
       path: `/chart-token/?image_url=${layout}&user_id=${userID}`,
-      headers: { cookie: session ? `sessionid=${session}` : '' },
+      headers: { cookie: session ? `sessionid=${session}${signature ? `;sessionid_sign=${signature};` : ''}` : '' },
     });
 
     if (!data.token) throw new Error('Wrong layout or credentials');
@@ -545,7 +553,7 @@ module.exports = {
    * @function getDrawings
    * @param {string} layout The layout ID found in the layout URL (Like: 'XXXXXXXX')
    * @param {string | ''} [symbol] Market filter (Like: 'BINANCE:BTCEUR')
-   * @param {UserCredentials} [credentials] User credentials (id + session)
+   * @param {UserCredentials} [credentials] User credentials (id + session + [signature])
    * @param {number} [chartID] Chart ID
    * @returns {Promise<Drawing[]>} Drawings
    */
@@ -553,12 +561,13 @@ module.exports = {
     const chartToken = await module.exports.getChartToken(layout, credentials);
     const creds = credentials.id && credentials.session;
     const session = creds ? credentials.session : null;
+    const signature = creds ? credentials.signature : null;
 
     const { data } = await request({
       host: 'charts-storage.tradingview.com',
       path: `/charts-storage/layout/${layout}/sources?chart_id=${chartID
       }&jwt=${chartToken}${symbol ? `&symbol=${symbol}` : ''}`,
-      headers: { cookie: session ? `sessionid=${session}` : '' },
+      headers: { cookie: session ? `sessionid=${session}${signature ? `;sessionid_sign=${signature};` : ''}` : '' },
     });
 
     if (!data.payload) throw new Error('Wrong layout, user credentials, or chart id.');

--- a/src/miscRequests.js
+++ b/src/miscRequests.js
@@ -377,7 +377,7 @@ module.exports = {
 
     const sessionCookie = cookies.find((c) => c.includes('sessionid='));
     const session = (sessionCookie.match(/sessionid=(.*?);/) ?? [])[1];
-    
+
     const signCookie = cookies.find((c) => c.includes('sessionid_sign='));
     const signature = (signCookie.match(/sessionid_sign=(.*?);/) ?? [])[1];
 

--- a/src/miscRequests.js
+++ b/src/miscRequests.js
@@ -439,7 +439,7 @@ module.exports = {
               authToken: /"auth_token":"(.*?)"/.exec(rs)[1],
               joinDate: new Date(/"date_joined":"(.*?)"/.exec(rs)[1] || 0),
             });
-          } else err(new Error('Wrong or expired sessionid'));
+          } else err(new Error('Wrong or expired sessionid/signature'));
         });
 
         res.on('error', err);

--- a/tests/09. AllErrors.js
+++ b/tests/09. AllErrors.js
@@ -177,7 +177,6 @@ module.exports = async (log, success, warn, err, cb) => {
   ];
 
   (async () => {
-    // eslint-disable-next-line no-restricted-syntax, no-await-in-loop
     for (const t of tests) await new Promise(t);
     success(`Crashtests ${tests.length}/${tests.length} done !`);
     cb();

--- a/tests/09. AllErrors.js
+++ b/tests/09. AllErrors.js
@@ -138,6 +138,13 @@ module.exports = async (log, success, warn, err, cb) => {
 
     async (next) => { /* Testing "Wrong or expired sessionid/signature" using getUser method */
       log('Testing "Wrong or expired sessionid/signature" error using getUser method:');
+
+      if (!process.env.SESSION) {
+        warn('=> Skipping test because no sessionid/signature was provided');
+        next();
+        return;
+      }
+
       try {
         await TradingView.getUser(process.env.SESSION);
         err('=> User found !');
@@ -149,6 +156,12 @@ module.exports = async (log, success, warn, err, cb) => {
 
     async (next) => { /* Testing "Wrong or expired sessionid/signature" using client */
       log('Testing "Wrong or expired sessionid/signature" error using client:');
+
+      if (!process.env.SESSION) {
+        warn('=> Skipping test because no sessionid/signature was provided');
+        next();
+        return;
+      }
 
       log('Creating a new client...');
       const client2 = new TradingView.Client({

--- a/tests/09. AllErrors.js
+++ b/tests/09. AllErrors.js
@@ -135,6 +135,32 @@ module.exports = async (log, success, warn, err, cb) => {
         next();
       });
     },
+
+    async (next) => { /* Testing "Wrong or expired sessionid/signature" using getUser method */
+      log('Testing "Wrong or expired sessionid/signature" error using getUser method:');
+      try {
+        await TradingView.getUser(process.env.SESSION);
+        err('=> User found !');
+      } catch (error) {
+        success('=> User not found:', error);
+        next();
+      }
+    },
+
+    async (next) => { /* Testing "Wrong or expired sessionid/signature" using client */
+      log('Testing "Wrong or expired sessionid/signature" error using client:');
+
+      log('Creating a new client...');
+      const client2 = new TradingView.Client({
+        token: process.env.SESSION,
+      });
+
+      client2.onError((...error) => {
+        success('=> Client error:', error);
+        client2.end();
+        next();
+      });
+    },
   ];
 
   (async () => {

--- a/tests/10. Authenticated.js
+++ b/tests/10. Authenticated.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax */
-/* eslint-disable no-await-in-loop */
 const TradingView = require('../main');
 
 const wait = (ms) => new Promise((cb) => { setTimeout(cb, ms); });

--- a/tests/10. Authenticated.js
+++ b/tests/10. Authenticated.js
@@ -5,6 +5,12 @@ const TradingView = require('../main');
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 module.exports = async (log, success, warn, err, cb) => {
+  if (!process.env.SESSION || !process.env.SIGNATURE) {
+    err('No sessionid/signature was provided');
+    cb();
+    return;
+  }
+
   log('Getting user info');
 
   const userInfos = await TradingView.getUser(process.env.SESSION, process.env.SIGNATURE);

--- a/tests/10. Authenticated.js
+++ b/tests/10. Authenticated.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-await-in-loop */
 const TradingView = require('../main');
 
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const wait = (ms) => new Promise((cb) => { setTimeout(cb, ms); });
 
 module.exports = async (log, success, warn, err, cb) => {
   if (!process.env.SESSION || !process.env.SIGNATURE) {

--- a/tests/10. Authenticated.js
+++ b/tests/10. Authenticated.js
@@ -28,8 +28,8 @@ module.exports = async (log, success, warn, err, cb) => {
   await wait(1000);
 
   log('Getting user indicators');
-
   const userIndicators = await TradingView.getPrivateIndicators(process.env.SESSION);
+
   if (userIndicators) {
     if (userIndicators.length === 0) warn('No private indicator found');
     else success('User indicators:', userIndicators.map((i) => i.name));
@@ -42,6 +42,7 @@ module.exports = async (log, success, warn, err, cb) => {
     token: process.env.SESSION,
     signature: process.env.SIGNATURE,
   });
+
   client.onError((...error) => {
     err('Client error', error);
   });
@@ -81,7 +82,6 @@ module.exports = async (log, success, warn, err, cb) => {
   await wait(1000);
 
   log('Loading indicators...');
-
   for (const indic of userIndicators) {
     const privateIndic = await indic.get();
     log(`[${indic.name}] Loading indicator...`);
@@ -97,4 +97,5 @@ module.exports = async (log, success, warn, err, cb) => {
       await check(indic.id);
     });
   }
+  log('Indicators loaded !');
 };

--- a/tests/10. Authenticated.js
+++ b/tests/10. Authenticated.js
@@ -7,7 +7,7 @@ const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 module.exports = async (log, success, warn, err, cb) => {
   log('Getting user info');
 
-  const userInfos = await TradingView.getUser(process.env.SESSION);
+  const userInfos = await TradingView.getUser(process.env.SESSION, process.env.SIGNATURE);
   if (userInfos && userInfos.id) {
     success('User info:', {
       id: userInfos.id,
@@ -36,6 +36,7 @@ module.exports = async (log, success, warn, err, cb) => {
   log('Creating logged client');
   const client = new TradingView.Client({
     token: process.env.SESSION,
+    signature: process.env.SIGNATURE,
   });
   client.onError((...error) => {
     err('Client error', error);

--- a/tests/10. Authenticated.js
+++ b/tests/10. Authenticated.js
@@ -4,7 +4,7 @@ const wait = (ms) => new Promise((cb) => { setTimeout(cb, ms); });
 
 module.exports = async (log, success, warn, err, cb) => {
   if (!process.env.SESSION || !process.env.SIGNATURE) {
-    err('No sessionid/signature was provided');
+    warn('No sessionid/signature was provided');
     cb();
     return;
   }


### PR DESCRIPTION
About 5 hours ago (`2023-05-04 10:30 UTC`) TV has re-introduced the need for a `sessionid_sign` cookie value in order to authenticate and get indicators data, as described in issue #187.

This patch add a completely optional support for that signature to v3.4.0.
Looking at the way TV staff is handling the feature, having it optional seems like a sensible choice.