### PR TITLE
refactor(tv): use global variables for tv domain and urls instead of hardcoded values

### DIFF
--- a/src/classes/PinePermManager.js
+++ b/src/classes/PinePermManager.js
@@ -1,4 +1,11 @@
 const axios = require('axios');
+const {
+  tvDomain,
+  tvListUsersUrl,
+  tvAddUserUrl,
+  tvModifyUserUrl,
+  tvRemoveUserUrl,
+} = require('../utils');
 
 /**
  * @typedef {Object} AuthorizationUser
@@ -44,11 +51,11 @@ class PinePermManager {
   async getUsers(limit = 10, order = '-created') {
     try {
       const { data } = await axios.post(
-        `https://www.tradingview.com/pine_perm/list_users/?limit=${limit}&order_by=${order}`,
+        `${tvListUsersUrl}?limit=${limit}&order_by=${order}`,
         `pine_id=${this.pineId.replace(/;/g, '%3B')}`,
         {
           headers: {
-            origin: 'https://www.tradingview.com',
+            origin: tvDomain,
             'Content-Type': 'application/x-www-form-urlencoded',
             cookie: `sessionid=${this.sessionId};sessionid_sign=${this.signature};`,
           },
@@ -70,7 +77,7 @@ class PinePermManager {
   async addUser(username, expiration = null) {
     try {
       const { data } = await axios.post(
-        'https://www.tradingview.com/pine_perm/add/',
+        tvAddUserUrl,
         `pine_id=${
           this.pineId.replace(/;/g, '%3B')
         }&username_recip=${
@@ -82,7 +89,7 @@ class PinePermManager {
         }`,
         {
           headers: {
-            origin: 'https://www.tradingview.com',
+            origin: tvDomain,
             'Content-Type': 'application/x-www-form-urlencoded',
             cookie: `sessionid=${this.sessionId};sessionid_sign=${this.signature};`,
           },
@@ -104,7 +111,7 @@ class PinePermManager {
   async modifyExpiration(username, expiration = null) {
     try {
       const { data } = await axios.post(
-        'https://www.tradingview.com/pine_perm/modify_user_expiration/',
+        tvModifyUserUrl,
         `pine_id=${
           this.pineId.replace(/;/g, '%3B')
         }&username_recip=${
@@ -116,7 +123,7 @@ class PinePermManager {
         }`,
         {
           headers: {
-            origin: 'https://www.tradingview.com',
+            origin: tvDomain,
             'Content-Type': 'application/x-www-form-urlencoded',
             cookie: `sessionid=${this.sessionId};sessionid_sign=${this.signature};`,
           },
@@ -137,11 +144,11 @@ class PinePermManager {
   async removeUser(username) {
     try {
       const { data } = await axios.post(
-        'https://www.tradingview.com/pine_perm/remove/',
+        tvRemoveUserUrl,
         `pine_id=${this.pineId.replace(/;/g, '%3B')}&username_recip=${username}`,
         {
           headers: {
-            origin: 'https://www.tradingview.com',
+            origin: tvDomain,
             'Content-Type': 'application/x-www-form-urlencoded',
             cookie: `sessionid=${this.sessionId};sessionid_sign=${this.signature};`,
           },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,21 @@
+const TV_DOMAIN = 'https://www.tradingview.com';
+const TV_SIGN_IN_PATH = '/accounts/signin';
+const TV_FIND_INDICATOR_PATH = '/pubscripts-suggest-json/';
+const TV_CHART_TOKEN_PATH = '/chart-token/';
+const TV_LIST_USERS_PATH = '/pine_perm/list_users/';
+const TV_ADD_USER_PATH = '/pine_perm/add/';
+const TV_MODIFY_USER_PATH = '/pine_perm/modify_user_expiration/';
+const TV_REMOVE_USER_PATH = '/pine_perm/remove';
+
 module.exports = {
+  tvDomain: TV_DOMAIN,
+  tvSignInUrl: TV_DOMAIN + TV_SIGN_IN_PATH,
+  tvFindIndicatorUrl: TV_DOMAIN + TV_FIND_INDICATOR_PATH,
+  tvChartTokenUrl: TV_DOMAIN + TV_CHART_TOKEN_PATH,
+  tvListUsersUrl: TV_DOMAIN + TV_LIST_USERS_PATH,
+  tvAddUserUrl: TV_DOMAIN + TV_ADD_USER_PATH,
+  tvModifyUserUrl: TV_DOMAIN + TV_MODIFY_USER_PATH,
+  tvRemoveUserUrl: TV_DOMAIN + TV_REMOVE_USER_PATH,
   /**
    * Generates a session id
    * @function genSessionID


### PR DESCRIPTION
### Overview

The goal of this PR is to move the TradingView domain and any URLs built on top of it to global variables

##### Pros

- Better maintainability: if in the future domain or url paths change we only need to modify a single file rather than finding and replacing all occurrences
- Better readability: urls now have human readable names and are shorter

##### Cons

- ~Variable is sometimes used in referer or origin (header) and in the endpoints so if those diverge at some point we wouldn't want to risk modifying one and breaking the other but I think this is already the case regardless of this PR~
- Let me know in the comments

##### Notes

I only refactored for the TradingView domain related URLs but we could do the same for the others as well ... I can do it on this PR if y'all agree or make another one later.