### PR TITLE
fix(getUser): deal with unexpected notifications structure

### DIFF
--- a/src/miscRequests.js
+++ b/src/miscRequests.js
@@ -412,8 +412,8 @@ module.exports = {
         following: parseFloat(/,"following":([0-9]*?),/.exec(data)?.[1] || 0),
         followers: parseFloat(/,"followers":([0-9]*?),/.exec(data)?.[1] || 0),
         notifications: {
-          following: parseFloat(/"notification_count":\{"following":([0-9]*),/.exec(data)?.[1] || 0),
-          user: parseFloat(/"notification_count":\{"following":[0-9]*,"user":([0-9]*)/.exec(data)?.[1] || 0),
+          following: parseFloat(/"notification_count":\{"following":([0-9]*),/.exec(data)?.[1] ?? 0),
+          user: parseFloat(/"notification_count":\{"following":[0-9]*,"user":([0-9]*)/.exec(data)?.[1] ?? 0),
         },
         session,
         signature,


### PR DESCRIPTION
Fixing the issue: https://github.com/Mathieu2301/TradingView-API/issues/243

# Pre-requisites

- [x] example of the response highlighting the unexpected notifications structure

```
"notification_count":{"following":{},"user":{}}
```

- [x] proof of a successful test run

![image](https://github.com/user-attachments/assets/8f709027-e9c7-4e3f-8d29-25af6723727d)
