### PR TITLE
Added backadjustment parameter to session.js

### DIFF
--- a/src/chart/session.js
+++ b/src/chart/session.js
@@ -331,6 +331,7 @@ module.exports = (client) => class ChartSession {
    * @param {number} [options.range] Number of loaded periods/candles (Default: 100)
    * @param {number} [options.to] Last candle timestamp (Default is now)
    * @param {'splits' | 'dividends'} [options.adjustment] Market adjustment
+   * @param {boolean} [options.backadjustment] Market backadjustment of futures contracts
    * @param {'regular' | 'extended'} [options.session] Chart session
    * @param {'EUR' | 'USD' | string} [options.currency] Chart currency
    * @param {ChartType} [options.type] Chart custom type
@@ -350,6 +351,7 @@ module.exports = (client) => class ChartSession {
       adjustment: options.adjustment || 'splits',
     };
 
+    if (options.backadjustment) symbolInit.backadjustment = 'default';
     if (options.session) symbolInit.session = options.session;
     if (options.currency) symbolInit['currency-id'] = options.currency;
 


### PR DESCRIPTION
Added backadjustment parameter to session.js, this will allow to defne if futures contracts should be backadjusted in terms of roll yield or not. I find it very useful, as it reflects real returns in that case. If you find it useful too, please do accept, if not thank you for this great repo anyway! All best Sveto