### PR TITLE
Fix for bug#259

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -217,6 +217,7 @@ module.exports = class Client {
    * @prop {string} [signature] User auth token signature (in 'sessionid_sign' cookie)
    * @prop {boolean} [DEBUG] Enable debug mode
    * @prop {'data' | 'prodata' | 'widgetdata'} [server] Server type
+   * @prop {string} [location] Auth page location (For france: https://fr.tradingview.com/)
    */
 
   /** Client object
@@ -234,6 +235,7 @@ module.exports = class Client {
       misc.getUser(
         clientOptions.token,
         clientOptions.signature ? clientOptions.signature : '',
+        clientOptions.location ? clientOptions.location : "https://tradingview.com",
       ).then((user) => {
         this.#sendQueue.unshift(protocol.formatWSPacket({
           m: 'set_auth_token',


### PR DESCRIPTION
Fix for #259 

**Root cause**

The client constructor relies on the `getUser` method of the `miscRequests` module, which requires location-specific URL to be passed as one of its arguments.

Added a property `location` to the `clientOptions` object passed to the client constructor. This `location` field will then be passed to the `getUser` method within the constructor.