### PR TITLE
Getting id of market in searchMarketV3 fix

### DIFF
--- a/src/miscRequests.js
+++ b/src/miscRequests.js
@@ -160,7 +160,7 @@ module.exports = {
 
     return data.symbols.map((s) => {
       const exchange = s.exchange.split(' ')[0];
-      const id = `${exchange.toUpperCase()}:${s.symbol}`;
+      const id = s.prefix ? `${s.prefix}:${s.symbol}` : `${exchange.toUpperCase()}:${s.symbol}`;
 
       return {
         id,


### PR DESCRIPTION
In some cases, the market id not equals to the concatenation of exchange name and symbol, but a special prefix is ​​also returned. For example, EURUSD from the FXCM exchange is FX:EURSD.