### PR TITLE
WAF Bypass && getUser max redirect

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -158,6 +158,7 @@ module.exports = class Client {
     if (!this.isOpen) return;
 
     protocol.parseWSPacket(str).forEach((packet) => {
+      console.dir(packet, { depth: null });
       if (global.TW_DEBUG) console.log('§90§30§107 CLIENT §0 PACKET', packet);
       if (typeof packet === 'number') { // Ping
         this.#ws.send(protocol.formatWSPacket(`~h~${packet}`));
@@ -228,8 +229,14 @@ module.exports = class Client {
     if (clientOptions.DEBUG) global.TW_DEBUG = clientOptions.DEBUG;
 
     const server = clientOptions.server || 'data';
-    this.#ws = new WebSocket(`wss://${server}.tradingview.com/socket.io/websocket?type=chart`, {
+    this.#ws = new WebSocket(`wss://${server}.tradingview.com/socket.io/websocket?from=chart&type=chart`, {
       origin: 'https://www.tradingview.com',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+      },
     });
 
     if (clientOptions.token) {

--- a/src/client.js
+++ b/src/client.js
@@ -158,7 +158,6 @@ module.exports = class Client {
     if (!this.isOpen) return;
 
     protocol.parseWSPacket(str).forEach((packet) => {
-      console.dir(packet, { depth: null });
       if (global.TW_DEBUG) console.log('§90§30§107 CLIENT §0 PACKET', packet);
       if (typeof packet === 'number') { // Ping
         this.#ws.send(protocol.formatWSPacket(`~h~${packet}`));

--- a/src/client.js
+++ b/src/client.js
@@ -230,6 +230,7 @@ module.exports = class Client {
 
     const server = clientOptions.server || 'data';
     const defaultHeaders = {
+      // eslint-disable-next-line max-len
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
       'Accept-Language': 'en-US,en;q=0.9',
       'Cache-Control': 'no-cache',

--- a/src/client.js
+++ b/src/client.js
@@ -218,7 +218,7 @@ module.exports = class Client {
    * @prop {boolean} [DEBUG] Enable debug mode
    * @prop {'data' | 'prodata' | 'widgetdata'} [server] Server type
    * @prop {string} [location] Auth page location (For france: https://fr.tradingview.com/)
-   * @prop {Object<string, string>} [headers] Custom headers for the WebSocket connection (e.g. for WAF bypass)
+   * @prop {Object<string, string>} [headers] Custom WebSocket headers
    */
 
   /**

--- a/src/client.js
+++ b/src/client.js
@@ -218,6 +218,7 @@ module.exports = class Client {
    * @prop {boolean} [DEBUG] Enable debug mode
    * @prop {'data' | 'prodata' | 'widgetdata'} [server] Server type
    * @prop {string} [location] Auth page location (For france: https://fr.tradingview.com/)
+   * @prop {Object<string, string>} [headers] Custom headers for the WebSocket connection (e.g. for WAF bypass)
    */
 
   /**
@@ -228,14 +229,16 @@ module.exports = class Client {
     if (clientOptions.DEBUG) global.TW_DEBUG = clientOptions.DEBUG;
 
     const server = clientOptions.server || 'data';
+    const defaultHeaders = {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Cache-Control': 'no-cache',
+      Pragma: 'no-cache',
+    };
+
     this.#ws = new WebSocket(`wss://${server}.tradingview.com/socket.io/websocket?from=chart&type=chart`, {
       origin: 'https://www.tradingview.com',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Cache-Control': 'no-cache',
-        Pragma: 'no-cache',
-      },
+      headers: { ...defaultHeaders, ...clientOptions.headers },
     });
 
     if (clientOptions.token) {

--- a/src/miscRequests.js
+++ b/src/miscRequests.js
@@ -427,7 +427,11 @@ module.exports = {
    * @param {string} [location] Auth page location (For france: https://fr.tradingview.com/)
    * @returns {Promise<User>} Token
    */
-  async getUser(session, signature = '', location = 'https://www.tradingview.com/') {
+  async getUser(session, signature = '', location = 'https://www.tradingview.com/', redirectCount = 0) {
+    if (redirectCount > 5) {
+      throw new Error('Too many redirects - invalid session/signature');
+    }
+
     const { data, headers } = await axios.get(location, {
       headers: {
         cookie: genAuthCookies(session, signature),
@@ -459,7 +463,7 @@ module.exports = {
     }
 
     if (headers.location !== location) {
-      return this.getUser(session, signature, headers.location);
+      return this.getUser(session, signature, headers.location, redirectCount + 1);
     }
 
     throw new Error('Wrong or expired sessionid/signature');

--- a/src/miscRequests.js
+++ b/src/miscRequests.js
@@ -431,7 +431,7 @@ module.exports = {
    */
   async getUser(session, signature = '', location = 'https://www.tradingview.com/', redirectCount = 0) {
     if (redirectCount > 5) {
-      throw new Error('Too many redirects - invalid session/signature');
+      throw new Error('Too many redirects - possible WAF or geo-restriction');
     }
 
     const { data, headers } = await axios.get(location, {

--- a/tests/getUser-redirect.test.ts
+++ b/tests/getUser-redirect.test.ts
@@ -6,7 +6,7 @@ describe('getUser redirect protection', () => {
     let callCount = 0;
     const axiosMock = {
       get: async (url: string) => {
-        callCount++;
+        callCount += 1;
         const isA = url === 'https://www.tradingview.com/';
         return {
           data: '<html>no auth here</html>',
@@ -32,6 +32,7 @@ describe('getUser redirect protection', () => {
     delete require.cache[miscPath];
 
     try {
+      // eslint-disable-next-line global-require
       const misc = require('../src/miscRequests');
       await expect(
         misc.getUser('fake_session', 'fake_signature'),

--- a/tests/getUser-redirect.test.ts
+++ b/tests/getUser-redirect.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+
+describe('getUser redirect protection', () => {
+  it('should not loop infinitely on repeated redirects', async () => {
+    // Monkey-patch axios in the require cache to simulate redirect loop
+    let callCount = 0;
+    const axiosMock = {
+      get: async (url: string) => {
+        callCount++;
+        const isA = url === 'https://www.tradingview.com/';
+        return {
+          data: '<html>no auth here</html>',
+          headers: {
+            location: isA
+              ? 'https://www.tradingview.com/accounts/signin/'
+              : 'https://www.tradingview.com/',
+          },
+        };
+      },
+    };
+
+    const axiosPath = require.resolve('axios');
+    const originalModule = require.cache[axiosPath];
+    require.cache[axiosPath] = {
+      id: axiosPath,
+      filename: axiosPath,
+      loaded: true,
+      exports: axiosMock,
+    } as any;
+
+    const miscPath = require.resolve('../src/miscRequests');
+    delete require.cache[miscPath];
+
+    try {
+      const misc = require('../src/miscRequests');
+      await expect(
+        misc.getUser('fake_session', 'fake_signature'),
+      ).rejects.toThrow('Too many redirects');
+
+      expect(callCount).toBeGreaterThan(0);
+      expect(callCount).toBeLessThanOrEqual(10);
+    } finally {
+      if (originalModule) require.cache[axiosPath] = originalModule;
+      else delete require.cache[axiosPath];
+      delete require.cache[miscPath];
+    }
+  }, 5000);
+});


### PR DESCRIPTION
## Summary
- Add default browser-like HTTP headers for WebSocket connections (required by TradingView WAF)
- Headers are configurable via `clientOptions.headers` — user values override defaults
- Add `from=chart` query param to WebSocket URL
- Add a max redirect limit (5) to `getUser()` to prevent infinite redirect loops caused by WAF or geo-restrictions
- Add unit test for redirect loop protection

## Usage

```js
// Default headers work out of the box
const client = new TradingView.Client();

// Users can override any header (e.g. rotate User-Agent, change language)
const client = new TradingView.Client({
  headers: {
    'User-Agent': 'Custom UA string',
    'Accept-Language': 'fr-FR,fr;q=0.9',
  },
});
```

## Before (infinite redirect loop in `getUser`)

```mermaid
sequenceDiagram
    participant Client
    participant TradingView

    Client->>TradingView: getUser(session) → GET /
    TradingView-->>Client: 302 → /accounts/signin/
    Client->>TradingView: getUser(session) → GET /accounts/signin/
    TradingView-->>Client: 302 → /
    Client->>TradingView: getUser(session) → GET /
    TradingView-->>Client: 302 → /accounts/signin/
    Note over Client,TradingView: ♻️ Infinite loop → OOM crash
```

## After (redirect protection)

```mermaid
sequenceDiagram
    participant Client
    participant TradingView

    Client->>TradingView: getUser(session, redirectCount=0) → GET /
    TradingView-->>Client: 302 → /accounts/signin/
    Client->>TradingView: getUser(session, redirectCount=1) → GET /accounts/signin/
    TradingView-->>Client: 302 → /
    Note over Client,TradingView: ...redirectCount increments each hop...
    Client->>TradingView: getUser(session, redirectCount=5) → GET /
    TradingView-->>Client: 302 → /accounts/signin/
    Client->>Client: redirectCount > 5 → throw Error
    Note over Client: "Too many redirects - possible WAF or geo-restriction"
```

## Test plan
- [x] Verify WebSocket connection works with default headers
- [x] Verify `clientOptions.headers` overrides defaults
- [x] Verify `getUser()` works with valid session/signature credentials
- [x] Verify `getUser()` throws after 5 redirects instead of looping forever
- [x] Verify the `from=chart` query param addition does not break existing chart sessions
- [x] Unit test for redirect loop protection

## Test notes

**Key finding:** TradingView now requires browser-like headers for WebSocket connections. Without them, connections hang even from non-restricted regions. Default headers are necessary, not optional.

**Redirect protection (TDD verified):**
| Branch | Mocked redirect loop | Real credentials |
|--------|---------------------|-----------------|
| `main` (before) | JS heap OOM — infinite recursion | Works (returns user) |
| `pr-310` (after) | Throws `"Too many redirects"` after 6 calls, 2ms | Works (returns user) |

**CI failures** (`builtInIndicator > gets volume profile`) are pre-existing and unrelated to this PR.

---
*This description was automatically generated by Claude.*