### PR TITLE
Stabilize TradingView indicator CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # TradingView authenticated tests use the same account/session secrets.
+      # Running every Node matrix job at once makes the external websocket tests flaky.
+      max-parallel: 1
       matrix:
         node-version: [14.x, 18.x, 19.x]
 

--- a/tests/indicators.test.ts
+++ b/tests/indicators.test.ts
@@ -119,7 +119,11 @@ describe('Indicators', () => {
 
     const lastResult: any = await new Promise((resolve) => {
       CipherB.onUpdate(() => {
-        resolve(CipherB.periods[0]);
+        const lastPeriod = CipherB.periods[0];
+
+        if (lastPeriod?.VWAP !== undefined && lastPeriod?.rsiMFI !== undefined) {
+          resolve(lastPeriod);
+        }
       });
     });
 
@@ -135,7 +139,7 @@ describe('Indicators', () => {
     expect(lastResult.Buy_and_sell_circle).toBeTypeOf('number');
 
     CipherB.remove();
-  });
+  }, 30000);
 
   it.skipIf(noAuth)('removes chart', () => {
     console.log('Closing the chart...');


### PR DESCRIPTION
## Summary
- Serialize the Node matrix jobs with `max-parallel: 1` because the authenticated TradingView tests share the same session secrets.
- Give the MarketCipher B websocket study test the same 30s timeout as the SuperTrend strategy test.
- Wait for actual MarketCipher values before resolving the test promise.

## Context
The post-merge Actions run for #316 no longer failed on SuperTrend. Node 14.x and 18.x timed out on `Indicators > gets data from MarketCipher B study`, while Node 19.x passed. That points to external TradingView websocket/session flakiness under concurrent matrix jobs rather than a deterministic code regression.

GitHub also reported a high `vite` Dependabot alert via `vitest`. `npm audit` proposes `vitest@4.1.9`, but that requires Node 20+, while this repo currently tests Node 14/18/19. I intentionally did not force that upgrade in this PR.

## Validation
- `npm test -- --run` → `50 passed | 16 skipped`

Signed-off-by: Nox <nox@molted.net>